### PR TITLE
remove notice

### DIFF
--- a/push7.php
+++ b/push7.php
@@ -289,6 +289,7 @@ class Push7 {
   }
 
   public static function user_agent() {
+    global $wp_version;
     return 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ) . '; Push7:' . self::VERSION;
   }
 


### PR DESCRIPTION
$wp_versionがグローバル宣言されておらず
Notice: Undefined variable $wp_version…… が出ていた
