### PR TITLE
$wp_version is global var

### DIFF
--- a/classes/push7.php
+++ b/classes/push7.php
@@ -66,7 +66,8 @@ class Push7 {
   }
 
   public static function user_agent() {
-    return 'WordPress/'.$wp_version.'; '.get_bloginfo('url').'; Push7:'.Push7::VERSION;
+    global $wp_version;
+    return 'WordPress/' . $wp_version . '; '.get_bloginfo('url') . '; Push7:' . Push7::VERSION;
   }
 
   public static function sslverify() {


### PR DESCRIPTION
以前のバージョンから存在していた問題だと記憶していますが、`$wp_version`に対して`global`宣言をしていないので Notice: Undefined variable が発生し、(それによりheader already sentになり)ページが読み込めなくなります。