### PR TITLE
MarsEditなどの外部エディタからの更新リクエストの対応を実装

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: php
+php:
+  - '5.3'
+script:
+- if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
+
 php:
   - '5.3'
+
 script:
 - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -15,21 +15,25 @@ class Push7_Post {
     }
 
     if (array_key_exists('metabox_exist', $_POST)) {
-      if (!empty($_POST['push7_not_notify'])) {
+      if (isset($_POST['push7_not_notify']) && $_POST['push7_not_notify'] == "false") {
         $_SESSION['notice_message'] = '右下の「通知を送信しない」のチェックボックスが入っていたため通知は送信されませんでした。';
         return;
       }
     } else {
-      if ($old_status === 'future') {
-        $future_opt_name = 'push7_future_'.$postData->ID;
-        if (get_option($future_opt_name) === false) {
-          return;
-        } else {
-          delete_option($future_opt_name);
-        }
-      } elseif ($this::push_default_config() === 'false') {
+      if(get_option("push7_update_from_thirdparty") == "false"){
         return;
       }
+    }
+
+    if ($old_status === 'future') {
+      $future_opt_name = 'push7_future_'.$postData->ID;
+      if (get_option($future_opt_name) === false) {
+        return;
+      } else {
+        delete_option($future_opt_name);
+      }
+    } elseif ($this::push_default_config() === 'false') {
+      return;
     }
 
     $this->push($postData);
@@ -122,8 +126,12 @@ class Push7_Post {
   public function metabox(){
     global $post;
     ?>
+      <style>[name="push7_not_notify"]:not([value="false"]){display:none;}</style>
       <input type="hidden" name="metabox_exist" value="true">
-      <input type="checkbox" name="push7_not_notify" value="false" <?php checked("false", self::push_default_config($post)); ?>>通知を送信しない
+      <input type="checkbox" name="push7_not_notify" value="false" <?php checked("false", self::push_default_config($post)); ?>>
+      <input type="checkbox" name="push7_not_notify" value="true" <?php checked("true", self::push_default_config($post)); ?>>
+      <script>jQuery(function(){var $ = jQuery;$("[name='push7_not_notify'][value='false']").click(function(e){$(this).siblings().click();})})</script>
+      通知を送信しない
     <?php
   }
 

--- a/classes/push7.php
+++ b/classes/push7.php
@@ -24,12 +24,18 @@ class Push7 {
     register_setting('push7-settings-group', 'push7_apikey');
     register_setting('push7-settings-group', 'push7_sslverify_disabled');
     register_setting('push7-settings-group', 'push7_sdk_enabled');
+    register_setting('push7-settings-group', 'push7_update_from_thirdparty');
 
     if (!get_option("push7_sslverify_disabled")) {
       update_option("push7_sslverify_disabled", "false");
     }
+
     if (!get_option("push7_sdk_enabled")) {
       update_option("push7_sdk_enabled", "false");
+    }
+
+    if (!get_option("push7_update_from_thirdparty")) {
+      update_option("push7_update_from_thirdparty", "false");
     }
 
     foreach (get_categories() as $category) {

--- a/setting.php
+++ b/setting.php
@@ -149,6 +149,35 @@
       </tr>
     </tbody></table>
 
+    <h2 class="title">サードパーティエディタのプッシュ通知設定</h2>
+
+    <p>
+      MarsEditなど、外部エディタを利用している場合の挙動についてはこちらをご利用ください。
+    </p>
+
+    <table class="form-table">
+      <tbody>
+        <tr>
+          <th>
+            記事更新時のプッシュ通知送信
+          </th>
+          <td>
+            <fieldset>
+              <label title="true">
+                <input type="radio" name="push7_update_from_thirdparty" value="true" <?php checked("true", get_option("push7_update_from_thirdparty")); ?>>
+                <?php _e( 'する', 'push7' ); ?>
+              </label>
+              <br>
+              <label title="false">
+                <input type="radio" name="push7_update_from_thirdparty" value="false" <?php checked("false", get_option("push7_update_from_thirdparty")); ?>>
+                <?php _e( 'しない', 'push7' ); ?>
+              </label>
+            </fieldset>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
     <?php submit_button(); ?>
 
     <button type="button" class="button action" onclick="show_debug_info()">デバッグ情報を出力する</button>


### PR DESCRIPTION
外部エディタからxmlrpc.php経由で投稿を行われた際、現状のチェックボックスの実装では挙動を無視して強制的に通知がおこなれるため、
それを対処するべく専用の設定を追加しました。

Review please @nkpoid @yoichiro-mikami