### PR TITLE
引数不足によるエラー

### DIFF
--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -32,7 +32,7 @@ class Push7_Post {
       } else {
         delete_option($future_opt_name);
       }
-    } elseif ($this::push_default_config() === 'false') {
+    } elseif ($this::push_default_config($postData) === 'false') {
       return;
     }
 
@@ -135,7 +135,8 @@ class Push7_Post {
     <?php
   }
 
-  public function push_default_config($post) {
+  public function push_default_config($post = null) {
+    $post = get_post($post);
     $opt = "push7_push_pt_".get_post_type($post);
     if ($post->post_status === 'publish') {
       return 'false';

--- a/push7.php
+++ b/push7.php
@@ -4,7 +4,7 @@
 Plugin Name: Push7
 Plugin URI: https://push7.jp/
 Description: Push7 plugin for WordPress
-Version: 2.2.0
+Version: 2.2.1
 Author: GNEX Ltd.
 Author URI: https://globalnet-ex.com
 License:GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gnexltd
 Tags: Chrome, Chrome Notifications, Android, Safari, push, push notifications, web push notifications, web push, plugin, admin, posts, page, links, widget, ajax, social, wordpress, dashboard, news, notifications, services, desktop notifications, mobile notifications, apple, google, Firefox, new post, osx, mac, Chrome OS
 Requires at least: 4.0
 Tested up to: 4.4.1
-Stable tag: 2.1.0
+Stable tag: 2.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,8 +24,11 @@ Push7 is now available for Chrome(Android and desktop).
 1. Open the settings menu, input your APPNO and APIKEY.
 
 == Changelog ==
-= 2.1.0 =
-* 2017-3-28 v2.0.xで発生していた、プラグインのアンインストールがダッシュボード経由でできない不具合を修正
+= 2.2.1 =
+* README修正
+
+= 2.2.0 =
+* 外部エディタによるPostの際に、プッシュ通知を行うかどうかの設定を追加
 
 = 2.0.2 =
 * 2017-3-27 プラグインファイルのファイル名が異なることによるプラグインが動作しない問題の解決


### PR DESCRIPTION
`Push7_Post::push_default_config()`の引数が指定されていずに投稿時にエラーが発生していたことのあった箇所の修正。

P. S. このメソッドってそもそも`static`付けておくべきなのでは。