### PR TITLE
投稿タイプ別設定とpush7_not_notifyの仕様見直した

### DIFF
--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -13,14 +13,13 @@ class Push7_Post {
     if ($new_status !== 'publish') {
       return;
     }
-
-    if (array_key_exists('metabox_exist', $_POST)) {
-      if (isset($_POST['push7_not_notify']) && $_POST['push7_not_notify'] == "false") {
-        $_SESSION['notice_message'] = '右下の「通知を送信しない」のチェックボックスが入っていたため通知は送信されませんでした。';
+    if ( isset( $_POST['push7_not_notify'] ) ) {
+      if ( $_POST['push7_not_notify'] === 'true' ) {
+        $_SESSION['p7_notice'] = '右下の「通知を送信しない」のチェックボックスが入っていたため通知は送信されませんでした。';
         return;
       }
     } else {
-      if(get_option("push7_update_from_thirdparty") == "false"){
+      if( get_option('push7_update_from_thirdparty') === 'false'){
         return;
       }
     }
@@ -32,7 +31,7 @@ class Push7_Post {
       } else {
         delete_option($future_opt_name);
       }
-    } elseif ($this::push_default_config($postData) === 'false') {
+    } elseif (!isset( $_POST['push7_not_notify'] ) && $this::push_default_config($postData) === 'false') {
       return;
     }
 
@@ -126,22 +125,19 @@ class Push7_Post {
   public function metabox(){
     global $post;
     ?>
-      <style>[name="push7_not_notify"]:not([value="false"]){display:none;}</style>
-      <input type="hidden" name="metabox_exist" value="true">
-      <input type="checkbox" name="push7_not_notify" value="false" <?php checked("false", self::push_default_config($post)); ?>>
-      <input type="checkbox" name="push7_not_notify" value="true" <?php checked("true", self::push_default_config($post)); ?>>
-      <script>jQuery(function(){var $ = jQuery;$("[name='push7_not_notify'][value='false']").click(function(e){$(this).siblings().click();})})</script>
+      <input type="hidden" name="push7_not_notify" value="false">
+      <input type="checkbox" name="push7_not_notify" value="true" <?php checked('false', self::push_default_config($post)); ?>>
       通知を送信しない
     <?php
   }
 
   public function push_default_config($post = null) {
     $post = get_post($post);
-    $opt = "push7_push_pt_".get_post_type($post);
+    $opt = "push7_push_pt_".$post->post_type;
     if ($post->post_status === 'publish') {
       return 'false';
     } else {
-      return var_export(get_option($opt), true);
+      return get_option($opt, 'false');
     }
   }
 }

--- a/classes/push7.php
+++ b/classes/push7.php
@@ -48,14 +48,14 @@ class Push7 {
 
     foreach (Push7::post_types() as $post_type) {
       $opt = "push7_push_pt_".$post_type;
-      register_setting('push7-settings-group', $opt);
+      register_setting('push7-settings-group', $opt, array('Push7', 'normalize_checkbox_val'));
       if ($post_type === 'post') {
         if (is_null(get_option($opt, null))) {
           update_option($opt, true);
         }
       } else {
         if (is_null(get_option($opt, null))) {
-          update_option($opt, false);
+          update_option($opt, 'false');
         }
       }
     }
@@ -97,5 +97,9 @@ class Push7 {
 
   public function add_setting_link($links){
     return array_merge($links, array('<a href="'.menu_page_url('push7', false).'">設定</a>'));
+  }
+
+  public static function normalize_checkbox_val($val) {
+    return (string)$val === 'true' ? 'true' : 'false';
   }
 }


### PR DESCRIPTION
投稿タイプデフォルト設定が機能していない問題にも対処。クソ。
https://wordpress.org/support/topic/%E3%83%87%E3%83%95%E3%82%A9%E3%83%AB%E3%83%88%E3%81%AE%E9%80%9A%E7%9F%A5%E3%82%AA%E3%83%B3%E3%82%AA%E3%83%95%E3%81%AE%E8%A8%AD%E5%AE%9A%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6/