### PR TITLE
travis: 判定がうまくいっていなかった為修正

### DIFF
--- a/.deploy.sh
+++ b/.deploy.sh
@@ -11,24 +11,35 @@ fi
 CURRENT_VERSION=$(grep 'Stable tag:' readme.txt | cut -d' ' -f3)
 # .git削除のためコピー
 cp -r ./ ../push7-publishee
-# svn checkoutし作業する為に移動
+# 作業する為に移動
 cd ../
 # subversionの中に.gitを保存したくないので削除
 rm -rf ./push7-publishee/.git
+
+# svnリポジトリをcheckout
 svn checkout https://plugins.svn.wordpress.org/push7/
 cd ./push7/
-# subversionに現在のタグリリースがない場合にリリースを行う
-if [ ! -d "tags/$CURRENT_VERSION" ]; then
-  # 現状のtrunk削除
-  svn remove ./trunk
-  cp -r ../push7-publishee ./trunk
-  svn add ./trunk
-  # タグを作成
-  cp -r ../push7-publishee "./tags/$CURRENT_VERSION"
-  svn add "./tags/$CURRENT_VERSION"
-  # コミットする
-  svn commit -m "release for $TRAVIS_COMMIT" --username $WP_USER --password $WP_PASSWORD
-  [ $? -eq 0 ] && echo "バージョン $CURRENT_VERSION がリリースされました。"
-else
+
+# subversionに現在のタグリリースがある場合に終了
+if [ -d "tags/$CURRENT_VERSION" ]
+then
   echo "バージョン $CURRENT_VERSION はすでにリリースされています。"
+  exit 0
 fi
+
+# 現状のtrunk削除
+svn remove ./trunk
+cp -r ../push7-publishee ./trunk
+svn add ./trunk
+# タグを作成
+cp -r ../push7-publishee "./tags/$CURRENT_VERSION"
+svn add "./tags/$CURRENT_VERSION"
+# コミットする
+svn commit -m "release for $TRAVIS_COMMIT" --username $WP_USER --password $WP_PASSWORD
+
+# svnコミットのステータスをキャッシュ
+code=$?
+# 成功時は成功したことを表示
+[ $code -eq 0 ] && echo "バージョン $CURRENT_VERSION がリリースされました。" || echo "バージョン $CURRENT_VERSION のリリースが失敗しました。"
+# キャッシュしたステータスで終了
+exit $code

--- a/.deploy.sh
+++ b/.deploy.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# ブランチがmasterではない、もしくはPRであった場合に終了
+if [ "$TRAVIS_BRANCH" != "master" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ]
+then
+  echo "ブランチがmasterではない、もしくはPull Requestである為リリースは行われません。"
+  exit 0
+fi
+
 # バージョン取得
 CURRENT_VERSION=$(grep 'Stable tag:' readme.txt | cut -d' ' -f3)
 # .git削除のためコピー
@@ -21,7 +28,7 @@ if [ ! -d "tags/$CURRENT_VERSION" ]; then
   svn add "./tags/$CURRENT_VERSION"
   # コミットする
   svn commit -m "release for $TRAVIS_COMMIT" --username $WP_USER --password $WP_PASSWORD
-  [ $? -eq 0 ] && echo "バージョン ($CURRENT_VERSION) がリリースされました"
+  [ $? -eq 0 ] && echo "バージョン $CURRENT_VERSION がリリースされました。"
 else
-  echo "このバージョン ($CURRENT_VERSION) はすでにリリースされています"
+  echo "バージョン $CURRENT_VERSION はすでにリリースされています。"
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ script:
 - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;
 
 after_success:
-- if [ $TRAVIS_BRANCH = "master" ] && [ $TRAVIS_PULL_REQUEST = "false" ]; then ./deploy.sh; fi;
+- bash .deploy.sh


### PR DESCRIPTION
masterにマージされたにもかかわらずdeployが走らなかった為修正
- travis.ymlにあると可読性が低いため.deploy.sh側で判定するように
  注釈: 環境変数の為に子シェルでも問題なく引き継がれ、判定できます
- また、いくつかの文面を修正