### PR TITLE
Travis CIでのsubversionの挙動に合わせた修正

### DIFF
--- a/.deploy.sh
+++ b/.deploy.sh
@@ -34,6 +34,13 @@ svn add ./trunk
 # タグを作成
 cp -r ../push7-publishee "./tags/$CURRENT_VERSION"
 svn add "./tags/$CURRENT_VERSION"
+
+# svnがパスワードを保存しようとするのを抑制
+cat <<EOS >> ~/.subversion/config
+store-passwords = no
+store-plaintext-passwords = no
+EOS
+
 # コミットする
 svn commit -m "release for $TRAVIS_COMMIT" --username $WP_USER --password $WP_PASSWORD
 

--- a/.deploy.sh
+++ b/.deploy.sh
@@ -21,14 +21,16 @@ svn checkout https://plugins.svn.wordpress.org/push7/
 cd ./push7/
 
 # subversionに現在のタグリリースがある場合に終了
-if [ -d "tags/$CURRENT_VERSION" ]
+if [ -d "./tags/$CURRENT_VERSION" ]
 then
   echo "バージョン $CURRENT_VERSION はすでにリリースされています。"
   exit 0
 fi
 
-# 現状のtrunk削除
+# 現状のtrunkをリポジトリの履歴から削除
 svn remove ./trunk
+# svn removeで削除されない場合を考慮しrmで削除
+rm -rf ./trunk
 cp -r ../push7-publishee ./trunk
 svn add ./trunk
 # タグを作成


### PR DESCRIPTION
~手元環境で一度commitしているのに再現しなかったの意味がわからない~
エラーメッセージを読み直したところ暗号化が有効になっていないからパスワードを保存できないというだけであり、ディストリビューションのデフォルト設定もしくはバージョン違いに拠りデフォルト設定が違うということだろうと思われます (設定未確認)