### PR TITLE
trusty環境のみでリリースするように

### DIFF
--- a/.deploy.sh
+++ b/.deploy.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# trusty環境でのみリリースするように
+if [ "$BUILD_DIST" != "trusty" ]
+then
+  echo "デプロイはtrusty環境で行われます。"
+  exit 0
+fi
+
 # ブランチがmasterではない、もしくはPRであった場合に終了
 if [ "$TRAVIS_BRANCH" != "master" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ]
 then
@@ -27,10 +34,8 @@ then
   exit 0
 fi
 
-# 現状のtrunkをリポジトリの履歴から削除
+# 現状のtrunkを削除
 svn remove ./trunk
-# svn removeで削除されない場合を考慮しrmで削除
-rm -rf ./trunk
 cp -r ../push7-publishee ./trunk
 svn add ./trunk
 # タグを作成

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: php
 
-php:
-  - 5.3
+matrix:
+  include:
+    - php: '5.3'
+    - php: nightly
+      dist: trusty
+      env: BUILD_DIST=trusty
 
 script:
 - if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;


### PR DESCRIPTION
また、trunkが削除されないのはsubversionが古い故にディレクトリ毎に.svnが保持される為だった為削除
https://github.com/gnexltd/push7-wp-plugin/commit/a425e568974dc6970b07084bab9838ccef39bc84

fix #44.