### PR TITLE
v3.0.0 外部エディタ対応の機能を削除

### DIFF
--- a/classes/push7-admin-menu.php
+++ b/classes/push7-admin-menu.php
@@ -27,8 +27,7 @@ class Push7_Admin_Menu {
       'system' => php_uname(),
       'php_ver' => phpversion(),
       'appno' => get_option('push7_appno'),
-      'sdk_enabled' => get_option('push7_sdk_enabled'),
-      'update_from_thirdparty' => get_option('push7_update_from_thirdparty')
+      'sdk_enabled' => get_option('push7_sdk_enabled')
     );
     return base64_encode(json_encode($data));
   }

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -17,8 +17,6 @@ class Push7_Post {
         $_SESSION['notice_message'] = '右下の「通知を送信しない」のチェックボックスが入っていたため通知は送信されませんでした。';
         return;
       }
-    } elseif(get_option('push7_update_from_thirdparty') == 'false') {
-      return;
     }
 
     if ($old_status === 'future') {

--- a/classes/push7.php
+++ b/classes/push7.php
@@ -2,7 +2,7 @@
 
 class Push7 {
   const API_URL = 'https://api.push7.jp/api/v1/';
-  const VERSION = '2.4.0';
+  const VERSION = '3.0.0';
 
   public function __construct() {
     new Push7_Admin_Menu();
@@ -60,8 +60,7 @@ class Push7 {
 
     $default_check_options = array(
       'push7_sslverify_disabled',
-      'push7_sdk_enabled',
-      'push7_update_from_thirdparty'
+      'push7_sdk_enabled'
     );
 
     $settings_params = array(
@@ -69,8 +68,7 @@ class Push7 {
       'push7_appno',
       'push7_apikey',
       'push7_sslverify_disabled',
-      'push7_sdk_enabled',
-      'push7_update_from_thirdparty'
+      'push7_sdk_enabled'
     );
 
     foreach ($settings_params as $setting) {

--- a/push7.php
+++ b/push7.php
@@ -4,7 +4,7 @@
 Plugin Name: Push7
 Plugin URI: https://push7.jp/
 Description: Push7 plugin for WordPress
-Version: 2.4.0
+Version: 3.0.0
 Author: GNEX Ltd.
 Author URI: https://globalnet-ex.com
 License:GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gnexltd
 Tags: Chrome, Chrome Notifications, Android, Safari, push, push notifications, web push notifications, web push, plugin, admin, posts, page, links, widget, ajax, social, wordpress, dashboard, news, notifications, services, desktop notifications, mobile notifications, apple, google, Firefox, new post, osx, mac, Chrome OS
 Requires at least: 4.0
 Tested up to: 4.4.1
-Stable tag: 2.4.0
+Stable tag: 3.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ Push7 is now available for Chrome(Android and desktop).
 1. Open the settings menu, input your APPNO and APIKEY.
 
 == Changelog ==
+= 3.0.0 =
+* 外部エディタ対応のコードを削除（今後はRSS連携による配信をご利用ください）
+
 = 2.4.0 =
 * UserAgentにPHPのバージョンが乗るように
 

--- a/setting.php
+++ b/setting.php
@@ -176,28 +176,6 @@ function show_advances_info() {
           <tr>
             <th>
               <label for="push7_sslverify_disabled">
-                外部エディタのプッシュ通知
-              </label>
-            </th>
-            <td>
-              <fieldset>
-                <label title="true">
-                  <input type="radio" name="push7_update_from_thirdparty" value="true" <?php checked("true", get_option("push7_update_from_thirdparty")); ?>>
-                  する
-                </label>
-                <br>
-                <label title="false">
-                  <input type="radio" name="push7_update_from_thirdparty" value="false" <?php checked("false", get_option("push7_update_from_thirdparty")); ?>>
-                  しない
-                </label>
-              </fieldset>
-              <span>MarsEditなど、外部エディタを利用している場合の挙動についてはこちらをご利用ください。</span>
-            </td>
-          </tr>
-
-          <tr>
-            <th>
-              <label for="push7_sslverify_disabled">
                 デバッグ情報
               </label>
             </th>


### PR DESCRIPTION
WPプラグインとしてはサポートしない方針となったため削除。