### PR TITLE
travis: subversionにパスワードを保存させない

### DIFF
--- a/.deploy.sh
+++ b/.deploy.sh
@@ -42,14 +42,8 @@ svn add ./trunk
 cp -r ../push7-publishee "./tags/$CURRENT_VERSION"
 svn add "./tags/$CURRENT_VERSION"
 
-# svnがパスワードを保存しようとするのを抑制
-cat <<EOS >> ~/.subversion/config
-store-passwords = no
-store-plaintext-passwords = no
-EOS
-
 # コミットする
-svn commit -m "release for $TRAVIS_COMMIT" --username $WP_USER --password $WP_PASSWORD
+svn commit -m "release for $TRAVIS_COMMIT" --username $WP_USER --password $WP_PASSWORD --no-auth-cache --non-interactive
 
 # svnコミットのステータスをキャッシュ
 code=$?


### PR DESCRIPTION
以下のコミットでは不十分だったようです
https://github.com/gnexltd/push7-wp-plugin/commit/5a3c24f4e321f824e1fa13549ef3ab9ce3eacd23