### PR TITLE
metabox_existの値をみて、外部からの更新は無視するように変更

### DIFF
--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -10,6 +10,7 @@ class Push7_Post {
     global $push7;
     $push7->init();
 
+    if (!isset($_POST['metabox_exist'])) return;
     if ($new_status !== 'publish') return;
 
     if (array_key_exists('metabox_exist', $_POST)) {


### PR DESCRIPTION
Fix #51 
外的要因による投稿の更新時に特別な配信が行われないように修正しました。