### PR TITLE
wp_remote_postのエラーハンドリング周りを修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 matrix:
   include:
-    - php: '5.3'
+    - php: '5.5'
     - php: nightly
       dist: trusty
       env: BUILD_DIST=trusty

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -74,8 +74,6 @@ class Push7_Post {
       )
     );
 
-    $message = json_decode($response['body']);
-
     if (is_wp_error($response)) {
       $_SESSION['p7_error'] = $response->get_error_message();
       return;
@@ -86,6 +84,7 @@ class Push7_Post {
       return;
     }
 
+    $message = json_decode($response['body']);
     $_SESSION['p7_success'] = '通知は正常に配信されました';
   }
 

--- a/classes/push7.php
+++ b/classes/push7.php
@@ -2,7 +2,7 @@
 
 class Push7 {
   const API_URL = 'https://api.push7.jp/api/v1/';
-  const VERSION = '3.0.2';
+  const VERSION = '3.0.3';
 
   public function __construct() {
     new Push7_Admin_Menu();

--- a/push7.php
+++ b/push7.php
@@ -4,7 +4,7 @@
 Plugin Name: Push7
 Plugin URI: https://push7.jp/
 Description: Push7 plugin for WordPress
-Version: 3.0.2
+Version: 3.0.3
 Author: GNEX Ltd.
 Author URI: https://globalnet-ex.com
 License:GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gnexltd
 Tags: Chrome, Chrome Notifications, Android, Safari, push, push notifications, web push notifications, web push, plugin, admin, posts, page, links, widget, ajax, social, wordpress, dashboard, news, notifications, services, desktop notifications, mobile notifications, apple, google, Firefox, new post, osx, mac, Chrome OS
 Requires at least: 4.0
 Tested up to: 4.4.1
-Stable tag: 3.0.2
+Stable tag: 3.0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ Push7 is now available for Chrome(Android and desktop).
 1. Open the settings menu, input your APPNO and APIKEY.
 
 == Changelog ==
+= 3.0.2 =
+* プッシュ通知の送信が失敗した時にエラーとなる問題を解消
+
 = 3.0.2 =
 * ドキュメントの不備を解消
 

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,7 @@ Push7 is now available for Chrome(Android and desktop).
 1. Open the settings menu, input your APPNO and APIKEY.
 
 == Changelog ==
-= 3.0.2 =
+= 3.0.3 =
 * プッシュ通知の送信が失敗した時にエラーとなる問題を解消
 
 = 3.0.2 =


### PR DESCRIPTION
wp_remote_postは返り値がmixedであり、array or WP_Errorを返しますが、WP_Errorの異常処理より先にArrayを前提とした処理が存在したため修正しました。

- https://codex.wordpress.org/Function_Reference/wp_remote_post