### PR TITLE
すべての投稿をReserved Pushとして扱う

### DIFF
--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -185,15 +185,29 @@ class Push7_Post {
     return true;
   }
 
+  /**
+   * get_rpid_dict 投稿ID:Reserved PushのIDの辞書を取得する
+   * @return array 投稿ID:Reserved PushのIDの辞書データとなる連想配列
+   */
+  protected function get_rpid_dict() {
+    return json_decode(get_option("push7_rpid_dict", '{}'), true);
+  }
+
+  /**
+   * get_rpid_from_post_data 投稿データから対象となるReserved PushのIDを引いてくる
+   * @param WP_Post $post 投稿データ
+   * @return mixed 対象ID(string) or 0
+   */
   protected function get_rpid_from_post_data($post) {
     $rpid_dict = $this->get_rpid_dict();
     return isset($rpid_dict[get_post($post)->ID]) ? $rpid_dict[get_post($post)->ID] : 0;
   }
 
-  protected function get_rpid_dict() {
-    return json_decode(get_option("push7_rpid_dict", '{}'), true);
-  }
-
+  /**
+   * set_ripd_dict 投稿ID:Reserved PushのIDの辞書を更新する
+   * @param WP_Post $post 投稿データ
+   * @param mixed $id   Reserved PushのID(string) or null
+   */
   protected function set_ripd_dict($post, $id) {
     $rpid_dict = $this->get_rpid_dict();
     $rpid_dict[get_post($post)->ID] = $id;

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -18,11 +18,14 @@ class Push7_Post {
 
     if ($new_status == "publish") {
       if ($old_status != "future" && !isset($_POST['metabox_exist'])) return;
+      if (isset($_REQUEST['push7_not_notify'])) return;
       $this->push($post);
     }
 
     if ($new_status == "future") {
-      $response = $this->push($post);
+      if (!isset($_POST['metabox_exist'])) return;
+      if (isset($_REQUEST['push7_not_notify'])) return;
+      $response = $this->push($post, true);
       if($response) $this->set_ripd_dict($this->get_post_id($post), $response['pushid']);
     }
   }
@@ -64,10 +67,12 @@ class Push7_Post {
     $this->set_ripd_dict($post, null);
   }
 
-  public function push($post) {
+  public function push($post, $is_rp=false) {
 
-    $rp_id = $this->get_rpid_from_post_data($this->get_post_id($post));
-    if ($rp_id) return;
+    if ($is_rp) {
+      $rp_id = $this->get_rpid_from_post_data($this->get_post_id($post));
+      if ($rp_id) return;
+    }
 
     if(!self::check_ignored_posttype($this->get_post_id($post))){
       return;

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -10,23 +10,14 @@ class Push7_Post {
     global $push7;
     $push7->init();
 
-    if ($old_status == "future" && $new_status != "publish") {
-      $this->delete_reserved_push($post);
-    }
-
-    if($post->post_status == "auto-draft") return;
-
-    if ($new_status == "publish") {
-      if ($old_status != "future" && !isset($_POST['metabox_exist'])) return;
-      if (isset($_REQUEST['push7_not_notify'])) return;
-      $this->push($post);
-    }
+    if ($old_status == "future" && $new_status != "publish") $this->delete_reserved_push($post);
+    if ($post->post_status == "auto-draft") return;
+    if ($new_status == "publish" && $old_status != "future" && isset($_POST['metabox_exist'])) $this->push($post);
 
     if ($new_status == "future") {
       if (!isset($_POST['metabox_exist'])) return;
-      if (isset($_REQUEST['push7_not_notify'])) return;
       $response = $this->push($post, true);
-      if($response) $this->set_ripd_dict($this->get_post_id($post), $response['pushid']);
+      if ($response) $this->set_ripd_dict($this->get_post_id($post), $response['pushid']);
     }
   }
 
@@ -68,6 +59,7 @@ class Push7_Post {
   }
 
   public function push($post, $is_rp=false) {
+    if (isset($_REQUEST['push7_not_notify'])) return;
 
     if ($is_rp) {
       $rp_id = $this->get_rpid_from_post_data($this->get_post_id($post));


### PR DESCRIPTION
### About

- 既存のSendを全てReserved Pushに置き換える
- RPは予約投稿から公開以外の状態になる時は必ず一度削除を行う
- 通常投稿もRPを利用する

### ToDo

- [x] send → RPへの置き換え
- [x] RP状態の管理の実装
- [x] 配信しないにチェックを入れている場合に良い感じにする処理

### 挙動

- 下書き→公開の場合
  - `old_status != 'future' && new_status == 'publish'`
  - 単純にその時間の予約配信の登録を行う
- Any→予約投稿の場合
  - `new_status == 'future'`
  - 指定した投稿時間に対しての予約配信の登録を行う
- 予約投稿→公開以外の場合
  - `old_status == 'future' && new_status != 'publish'`
  - 現在登録されている予約投稿を削除する。現在予約されているプッシュ通知のIDをもつ必要があるので、update_optionでDBにもつ

### 備考

- 14日を越える場合に予約登録の設定ができない状態となっていますが、別途現在PRを作成中です。PRの大きさを抑えるためにもこれ単体でdevelopに導入したいです。