### PR TITLE
予約投稿のキューイング処理の実装

### DIFF
--- a/classes/push7-admin-queuing.php
+++ b/classes/push7-admin-queuing.php
@@ -2,10 +2,64 @@
 
 class Push7_Admin_Queuing {
   public function __construct() {
-    add_action('admin_menu', array($this, 'update_queue'));
+    add_action('admin_menu', array($this, 'on_init'));
   }
 
-  public function update_queue() {
-    
+  /**
+   * on_init メイン処理
+   * @return [type] [description]
+   */
+  public function on_init() {
+    $queue = self::get_queue();
+    foreach ($queue as $post_id) {
+      $post = get_post($post_id);
+      // 予約投稿日時が13日以内の場合
+      if ( (strtotime($post->post_date) - strtotime(current_time('Y-m-d H:i:s'))) < Push7::RESERVED_LINE ) {
+        $response = Push7_Post::push($post, true);
+        if($response) {
+          Push7_Post::set_ripd_dict($post->ID, $response['pushid']);
+          self::delete_queue($post->ID);
+        }
+      }
+    }
+  }
+
+  /**
+   * add_queue キューへの投稿の追加
+   * @param int $post_id 投稿ID
+   */
+  public static function add_queue($post_id) {
+    $queue = self::get_queue();
+    $queue[] = $post_id;
+    self::save_queue($queue);
+  }
+
+  /**
+   *
+   */
+  public static function delete_queue($post_id) {
+    $old_queue = self::get_queue();
+    $new_queue = array();
+    foreach ($old_queue as $item_id) {
+      if($item_id != $post_id) $new_queue[] = $item_id;
+    }
+    self::save_queue($new_queue);
+  }
+
+  /**
+   * get_queue Reserved Pushのキューを取得する
+   * @return array Reserved Pushのキュー
+   */
+  public static function get_queue() {
+    return json_decode(get_option("push7_rp_queue", '[]'), true);
+  }
+
+  /**
+   * save_queue キューをJSON化して保存する
+   * @param  [type] $queue [description]
+   * @return [type]        [description]
+   */
+  public static function save_queue($queue) {
+    update_option("push7_rp_queue", json_encode($queue));
   }
 }

--- a/classes/push7-admin-queuing.php
+++ b/classes/push7-admin-queuing.php
@@ -13,6 +13,9 @@ class Push7_Admin_Queuing {
    * @return [type] [description]
    */
   public static function update_queue() {
+    $semaphore = Push7_Semaphore::factory();
+    $semaphore->init();
+    if(!$semaphore->lock()) return;
     $queue = self::get_queue();
     foreach ($queue as $post_id) {
       $post = get_post($post_id);
@@ -25,6 +28,7 @@ class Push7_Admin_Queuing {
         }
       }
     }
+    $semaphore->unlock();
   }
 
   public function register_scheduler() {

--- a/classes/push7-admin-queuing.php
+++ b/classes/push7-admin-queuing.php
@@ -1,0 +1,11 @@
+<?php
+
+class Push7_Admin_Queuing {
+  public function __construct() {
+    add_action('admin_menu', array($this, 'update_queue'));
+  }
+
+  public function update_queue() {
+    
+  }
+}

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -13,8 +13,10 @@ class Push7_Post {
     global $push7;
     $push7->init();
 
-    if ($old_status == "future" && $new_status != "publish") Push7_Admin_Queuing::delete_queue(self::get_post_id($post));
-    if ($old_status == "future" && $new_status != "publish") $this->delete_reserved_push($post);
+    if ($old_status == "future" && $new_status != "publish") {
+      Push7_Admin_Queuing::delete_queue(self::get_post_id($post));
+      $this->delete_reserved_push($post);
+    }
     if ($post->post_status == "auto-draft") return;
     if ($new_status == "publish" && $old_status != "future" && isset($_POST['metabox_exist'])) self::push($post);
 

--- a/classes/push7-semaphore.php
+++ b/classes/push7-semaphore.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Semaphore Lock Management
+ * forked by: https://github.com/crowdfavorite/wp-social/blob/master/lib/social/semaphore.php
+ *
+ * @package Push7
+ */
+final class Push7_Semaphore {
+
+  /**
+   * Initializes the semaphore object.
+   *
+   * @static
+   * @return Push7_Semaphore
+   */
+  public static function factory() {
+    return new self;
+  }
+
+  /**
+   * @var bool
+   */
+  protected $lock_broke = false;
+
+  public function init() {
+    update_option('push7_semaphore', '0');
+    // ロックもアンロックもない初期状態の場合
+    if(get_option('push7_locked', null) == null && get_option('push7_unlocked', null) === null) {
+      update_option('push7_unlocked', '1');
+    }
+  }
+
+  /**
+   * Attempts to start the lock. If the rename works, the lock is started.
+   *
+   * @return bool
+   */
+  public function lock() {
+    global $wpdb;
+
+    // Attempt to set the lock
+    $affected = $wpdb->query("
+      UPDATE $wpdb->options
+         SET option_name = 'push7_locked'
+       WHERE option_name = 'push7_unlocked'
+    ");
+
+    if ($affected == '0' and !$this->stuck_check()) {
+      return false;
+    }
+
+    // Check to see if all processes are complete
+    $affected = $wpdb->query("
+      UPDATE $wpdb->options
+         SET option_value = CAST(option_value AS UNSIGNED) + 1
+       WHERE option_name = 'push7_semaphore'
+         AND option_value = '0'
+    ");
+    if ($affected != '1') {
+      if (!$this->stuck_check()) {
+        return false;
+      }
+
+      // Reset the semaphore to 1
+      $wpdb->query("
+        UPDATE $wpdb->options
+           SET option_value = '1'
+         WHERE option_name = 'push7_semaphore'
+      ");
+
+    }
+
+    // Set the lock time
+    $wpdb->query($wpdb->prepare("
+      UPDATE $wpdb->options
+         SET option_value = %s
+       WHERE option_name = 'push7_last_lock_time'
+    ", current_time('mysql', 1)));
+
+    return true;
+  }
+
+  /**
+   * Increment the semaphore.
+   *
+   * @param  array  $filters
+   * @return Push7_Semaphore
+   */
+  public function increment(array $filters = array()) {
+    global $wpdb;
+
+    if (count($filters)) {
+      // Loop through all of the filters and increment the semaphore
+      foreach ($filters as $priority) {
+        for ($i = 0, $j = count($priority); $i < $j; ++$i) {
+          $this->increment();
+        }
+      }
+    }
+    else {
+      $wpdb->query("
+        UPDATE $wpdb->options
+           SET option_value = CAST(option_value AS UNSIGNED) + 1
+         WHERE option_name = 'push7_semaphore'
+      ");
+    }
+
+    return $this;
+  }
+
+  /**
+   * Decrements the semaphore.
+   *
+   * @return void
+   */
+  public function decrement() {
+    global $wpdb;
+
+    $wpdb->query("
+      UPDATE $wpdb->options
+         SET option_value = CAST(option_value AS UNSIGNED) - 1
+       WHERE option_name = 'push7_semaphore'
+         AND CAST(option_value AS UNSIGNED) > 0
+    ");
+  }
+
+  /**
+   * Unlocks the process.
+   *
+   * @return bool
+   */
+  public function unlock() {
+    global $wpdb;
+
+    // Decrement for the master process.
+    $this->decrement();
+
+    $result = $wpdb->query("
+      UPDATE $wpdb->options
+         SET option_name = 'push7_unlocked'
+       WHERE option_name = 'push7_locked'
+    ");
+
+    if ($result == '1') {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Attempts to jiggle the stuck lock loose.
+   *
+   * @return bool
+   */
+  private function stuck_check() {
+    global $wpdb;
+
+    // Check to see if we already broke the lock.
+    if ($this->lock_broke) {
+      return true;
+    }
+
+    $current_time = current_time('mysql', 1);
+    $unlock_time = gmdate('Y-m-d H:i:s', time() - 30 * 60);
+    $affected = $wpdb->query($wpdb->prepare("
+      UPDATE $wpdb->options
+         SET option_value = %s
+       WHERE option_name = 'push7_last_lock_time'
+         AND option_value <= %s
+    ", $current_time, $unlock_time));
+
+    if ($affected == '1') {
+      $this->lock_broke = true;
+      return true;
+    }
+
+    return false;
+  }
+
+}

--- a/classes/push7.php
+++ b/classes/push7.php
@@ -3,6 +3,7 @@
 class Push7 {
   const API_URL = 'https://api.push7.jp/api/v1/';
   const VERSION = '3.0.3';
+  const RESERVED_LINE = 1123200; // 13 days (86,400 * 13)
 
   public function __construct() {
     new Push7_Admin_Menu();

--- a/classes/push7.php
+++ b/classes/push7.php
@@ -7,6 +7,7 @@ class Push7 {
   public function __construct() {
     new Push7_Admin_Menu();
     new Push7_Admin_Notices();
+    new Push7_Admin_Queuing();
     new Push7_Post();
     new Push7_Sdk();
 

--- a/push7.php
+++ b/push7.php
@@ -13,8 +13,9 @@ Text Domain: push7
 
 require_once 'classes/push7.php';
 require_once 'classes/push7-admin-notices.php';
-require_once 'classes/push7-admin-queuing.php';
 require_once 'classes/push7-admin-menu.php';
+require_once 'classes/push7-semaphore.php';
+require_once 'classes/push7-admin-queuing.php';
 require_once 'classes/push7-post.php';
 require_once 'classes/push7-sdk.php';
 

--- a/push7.php
+++ b/push7.php
@@ -13,6 +13,7 @@ Text Domain: push7
 
 require_once 'classes/push7.php';
 require_once 'classes/push7-admin-notices.php';
+require_once 'classes/push7-admin-queuing.php';
 require_once 'classes/push7-admin-menu.php';
 require_once 'classes/push7-post.php';
 require_once 'classes/push7-sdk.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -16,3 +16,5 @@ foreach ($post_types as $post_type) {
   $opt = "push7_push_pt_".$post_type;
   delete_option($opt);
 }
+
+wp_clear_scheduled_hook('push7_queue_cron');


### PR DESCRIPTION
### About

- 13日以降に設定されている予約投稿は一度キューとして保存する
  - WordPressの内蔵のローカル時差吸収関数current_timeで行う
- 管理画面読み込み時に13日以内になっていたらAPIを叩いてReserved Pushを作成する
- 一度作成した後はReserved Pushのwp_optionに同じように格納され、削除処理なども同じように行う

### あとでやる

- Push7_PostにAPI周りの処理があるので切り分ける（次回以降のPRで行う）

### 挙動

- 投稿時に13日以上未来かどうか?
  - 未来だった場合は一度push7_rp_queueに格納
- 管理画面アクセス時に13日以内の未来かつpush7_rp_queueに入っている投稿があるか？
  - あればRPを作成
  - 作成後問題がなければpush7_rpid_dictにRPのIDを作成
  - 作成後問題がなければpush7_rp_queueから該当の投稿IDを削除

### 備考

コードが大分つらいです。