### PR TITLE
予約投稿が送信されない問題の暫定的解消

### DIFF
--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -20,12 +20,6 @@ class Push7_Post {
       }
     }
 
-    if ($old_status === 'future') {
-      $future_opt_name = 'push7_future_'.$post_data->ID;
-      if (get_option($future_opt_name) === false) return;
-      delete_option($future_opt_name);
-    }
-
     if(!self::check_ignored_posttype($post_data)){
       return;
     }

--- a/classes/push7.php
+++ b/classes/push7.php
@@ -2,7 +2,7 @@
 
 class Push7 {
   const API_URL = 'https://api.push7.jp/api/v1/';
-  const VERSION = '3.0.3';
+  const VERSION = '3.0.4';
 
   public function __construct() {
     new Push7_Admin_Menu();

--- a/push7.php
+++ b/push7.php
@@ -4,7 +4,7 @@
 Plugin Name: Push7
 Plugin URI: https://push7.jp/
 Description: Push7 plugin for WordPress
-Version: 3.0.3
+Version: 3.0.4
 Author: GNEX Ltd.
 Author URI: https://globalnet-ex.com
 License:GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gnexltd
 Tags: Chrome, Chrome Notifications, Android, Safari, push, push notifications, web push notifications, web push, plugin, admin, posts, page, links, widget, ajax, social, wordpress, dashboard, news, notifications, services, desktop notifications, mobile notifications, apple, google, Firefox, new post, osx, mac, Chrome OS
 Requires at least: 4.0
 Tested up to: 4.4.1
-Stable tag: 3.0.3
+Stable tag: 3.0.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ Push7 is now available for Chrome(Android and desktop).
 1. Open the settings menu, input your APPNO and APIKEY.
 
 == Changelog ==
+= 3.0.4 =
+* 予約投稿が配信されない問題を解消
+
 = 3.0.3 =
 * プッシュ通知の送信が失敗した時にエラーとなる問題を解消
 


### PR DESCRIPTION
#58 で送信されない問題自体は解消されているものの、実際の時間と差がある(早い)、及び即時投稿の配信が遅いという問題があり、巻き取って改修を行うまでの暫定処理として既存masterのコードを削って対応する。

対応後はこのcommitをrevert後developをmergeする。(**Mergeの際にchangelogを追記すること**)