### PR TITLE
予約投稿が送信されない問題の解消

### DIFF
--- a/.scripts/deploy.sh
+++ b/.scripts/deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source .scripts/version-extractor.sh
+
 # trusty環境でのみリリースするように
 if [ "$BUILD_DIST" != "trusty" ]
 then
@@ -15,7 +17,7 @@ then
 fi
 
 # バージョン取得
-CURRENT_VERSION=$(grep 'Stable tag:' readme.txt | cut -d' ' -f3)
+CURRENT_VERSION=$(version_from_readme)
 # .git削除のためコピー
 cp -r ./ ../push7-publishee
 # 作業する為に移動

--- a/.scripts/syntax-check.sh
+++ b/.scripts/syntax-check.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+syntax () {
+    find . -name "*.php" -exec php -l {} \; 1>/dev/null
+}
+
+result="$(syntax 2>&1)"
+
+if [ "$result" ]
+then
+    echo $result >&2
+    exit 1
+fi

--- a/.scripts/version-check.sh
+++ b/.scripts/version-check.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+source .scripts/version-extractor.sh
+
+check () {
+    local version="$(version_from_readme)"
+    [ "$version" = "$(version_from_push7_class)" ] &&
+    [ "$version" = "$(version_from_main)" ]
+}
+
+check
+status=$?
+
+if [ $status -ne 0 ]
+then
+    cat >&2 <<MESSAGE
+バージョンが統一されていません
+    readme.txt: $(version_from_readme)
+    push7.php: $(version_from_main)
+    classes/push7.php: $(version_from_push7_class)
+MESSAGE
+fi
+
+exit $status

--- a/.scripts/version-extractor.sh
+++ b/.scripts/version-extractor.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+version_from_readme () {
+  grep 'Stable tag:' readme.txt | awk '{print $3}'
+}
+
+version_from_push7_class () {
+  grep 'VERSION = ' classes/push7.php | awk '{print $4}' | cut -d\' -f 2
+}
+
+version_from_main () {
+  grep 'Version: ' push7.php | awk '{print $2}'
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ matrix:
       env: BUILD_DIST=trusty
 
 script:
-- if find . -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi;
+- bash .scripts/syntax-check.sh
+- bash .scripts/version-check.sh
 
 after_success:
-- bash .deploy.sh
+- bash .scripts/deploy.sh

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -185,15 +185,29 @@ class Push7_Post {
     return true;
   }
 
+  /**
+   * get_rpid_dict 投稿ID:Reserved PushのIDの辞書を取得する
+   * @return array 投稿ID:Reserved PushのIDの辞書データとなる連想配列
+   */
+  protected function get_rpid_dict() {
+    return json_decode(get_option("push7_rpid_dict", '{}'), true);
+  }
+
+  /**
+   * get_rpid_from_post_data 投稿データから対象となるReserved PushのIDを引いてくる
+   * @param WP_Post $post 投稿データ
+   * @return mixed 対象ID(string) or 0
+   */
   protected function get_rpid_from_post_data($post) {
     $rpid_dict = $this->get_rpid_dict();
     return isset($rpid_dict[get_post($post)->ID]) ? $rpid_dict[get_post($post)->ID] : 0;
   }
 
-  protected function get_rpid_dict() {
-    return json_decode(get_option("push7_rpid_dict", '{}'), true);
-  }
-
+  /**
+   * set_ripd_dict 投稿ID:Reserved PushのIDの辞書を更新する
+   * @param WP_Post $post 投稿データ
+   * @param mixed $id   Reserved PushのID(string) or null
+   */
   protected function set_ripd_dict($post, $id) {
     $rpid_dict = $this->get_rpid_dict();
     $rpid_dict[get_post($post)->ID] = $id;

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -95,8 +95,7 @@ class Push7_Post {
     );
 
     // push7の予約投稿は分粒度での配信しかできないため、1分追加しないと記事公開前にpushが配送される可能性が高い.
-    $after_1_minute = date("Y-m-d H:i", strtotime(get_post($post)->post_date.'+1 minute'));
-    if ($is_rp) $data['transmission_time'] = substr($after_1_minute, 0, -3);
+    if ($is_rp) $data['transmission_time'] = date("Y-m-d H:i", strtotime(get_post($post)->post_date.'+1 minute'));
 
     $response = wp_remote_post(
       Push7::API_URL . $appno.'/send',

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -22,7 +22,6 @@ class Push7_Post {
   }
 
   protected function delete_reserved_push($post) {
-
     $rp_id = $this->get_rpid_from_post_data($post);
     if (!$rp_id) return;
 
@@ -92,9 +91,12 @@ class Push7_Post {
       'body' => $post->post_title,
       'icon' => $icon_url,
       'url' => get_permalink($post),
-      'apikey' => $apikey,
-      'transmission_time' => substr(get_post($post)->post_date, 0, -3)
+      'apikey' => $apikey
     );
+
+    // push7の予約投稿は分粒度での配信しかできないため、1分追加しないと記事公開前にpushが配送される可能性が高い.
+    $after_1_minute = date("Y-m-d H:i", strtotime(get_post($post)->post_date.'+1 minute'));
+    if ($is_rp) $data['transmission_time'] = substr($after_1_minute, 0, -3);
 
     $response = wp_remote_post(
       Push7::API_URL . $appno.'/send',

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -18,11 +18,14 @@ class Push7_Post {
 
     if ($new_status == "publish") {
       if ($old_status != "future" && !isset($_POST['metabox_exist'])) return;
+      if (isset($_REQUEST['push7_not_notify'])) return;
       $this->push($post);
     }
 
     if ($new_status == "future") {
-      $response = $this->push($post);
+      if (!isset($_POST['metabox_exist'])) return;
+      if (isset($_REQUEST['push7_not_notify'])) return;
+      $response = $this->push($post, true);
       if($response) $this->set_ripd_dict($this->get_post_id($post), $response['pushid']);
     }
   }
@@ -64,10 +67,12 @@ class Push7_Post {
     $this->set_ripd_dict($post, null);
   }
 
-  public function push($post) {
+  public function push($post, $is_rp=false) {
 
-    $rp_id = $this->get_rpid_from_post_data($this->get_post_id($post));
-    if ($rp_id) return;
+    if ($is_rp) {
+      $rp_id = $this->get_rpid_from_post_data($this->get_post_id($post));
+      if ($rp_id) return;
+    }
 
     if(!self::check_ignored_posttype($this->get_post_id($post))){
       return;

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -10,23 +10,14 @@ class Push7_Post {
     global $push7;
     $push7->init();
 
-    if ($old_status == "future" && $new_status != "publish") {
-      $this->delete_reserved_push($post);
-    }
-
-    if($post->post_status == "auto-draft") return;
-
-    if ($new_status == "publish") {
-      if ($old_status != "future" && !isset($_POST['metabox_exist'])) return;
-      if (isset($_REQUEST['push7_not_notify'])) return;
-      $this->push($post);
-    }
+    if ($old_status == "future" && $new_status != "publish") $this->delete_reserved_push($post);
+    if ($post->post_status == "auto-draft") return;
+    if ($new_status == "publish" && $old_status != "future" && isset($_POST['metabox_exist'])) $this->push($post);
 
     if ($new_status == "future") {
       if (!isset($_POST['metabox_exist'])) return;
-      if (isset($_REQUEST['push7_not_notify'])) return;
       $response = $this->push($post, true);
-      if($response) $this->set_ripd_dict($this->get_post_id($post), $response['pushid']);
+      if ($response) $this->set_ripd_dict($this->get_post_id($post), $response['pushid']);
     }
   }
 
@@ -68,6 +59,7 @@ class Push7_Post {
   }
 
   public function push($post, $is_rp=false) {
+    if (isset($_REQUEST['push7_not_notify'])) return;
 
     if ($is_rp) {
       $rp_id = $this->get_rpid_from_post_data($this->get_post_id($post));

--- a/classes/push7.php
+++ b/classes/push7.php
@@ -2,7 +2,7 @@
 
 class Push7 {
   const API_URL = 'https://api.push7.jp/api/v1/';
-  const VERSION = '3.0.3';
+  const VERSION = '3.0.4';
 
   public function __construct() {
     new Push7_Admin_Menu();

--- a/push7.php
+++ b/push7.php
@@ -4,7 +4,7 @@
 Plugin Name: Push7
 Plugin URI: https://push7.jp/
 Description: Push7 plugin for WordPress
-Version: 3.0.3
+Version: 3.0.4
 Author: GNEX Ltd.
 Author URI: https://globalnet-ex.com
 License:GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gnexltd
 Tags: Chrome, Chrome Notifications, Android, Safari, push, push notifications, web push notifications, web push, plugin, admin, posts, page, links, widget, ajax, social, wordpress, dashboard, news, notifications, services, desktop notifications, mobile notifications, apple, google, Firefox, new post, osx, mac, Chrome OS
 Requires at least: 4.0
 Tested up to: 4.4.1
-Stable tag: 3.0.3
+Stable tag: 3.0.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ Push7 is now available for Chrome(Android and desktop).
 1. Open the settings menu, input your APPNO and APIKEY.
 
 == Changelog ==
+= 3.0.4 =
+* 予約投稿が配信されない問題を解消
+
 = 3.0.3 =
 * プッシュ通知の送信が失敗した時にエラーとなる問題を解消
 


### PR DESCRIPTION
通常の投稿は即時投稿にし、予約投稿は確実に投稿がpublishされた後にpushを送信するようにした

- 通常の投稿はpublishした段階で配信される
- 予約投稿は記事公開後に配信される
- どちらの場合でも「通知しない」にチェックが入っていた場合は通知しない