### PR TITLE
[3.0.5] 投稿カテゴリの設定が適用されない問題を修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: php
 matrix:
   include:
     - php: '5.5.38'
+      dist: trusty
+      env: BUILD_DIST=trusty
+
     - php: nightly
       dist: trusty
       env: BUILD_DIST=trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 matrix:
   include:
-    - php: '5.5'
+    - php: '5.5.38'
     - php: nightly
       dist: trusty
       env: BUILD_DIST=trusty

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -65,13 +65,12 @@ class Push7_Post {
       if ($rp_id) return;
     }
 
-    if(!self::check_ignored_posttype($this->get_post_id($post))){
-      return;
-    }
+    $post_type = get_post_type($post_id);
+    $post_id = $this->get_post_id($post);
 
-    if(!self::check_ignored_category($this->get_post_id($post))){
-      return;
-    }
+    if ($this->check_ignored_posttype($post_id)) return;
+    // 通常投稿の場合のみカテゴリチェックを行う
+    if ($post_type === 'post' && $this->check_ignored_category($post_id)) return;
 
     $blogname = get_option(get_option('push7_blog_title', '') === '' ? 'blogname' : 'push7_blog_title');
     $appno = Push7::appno();
@@ -169,17 +168,17 @@ class Push7_Post {
 
   public function check_ignored_posttype($post_id){
     $post_type = get_post_type($post_id);
-    return $post_type == 'post' ?: !(get_option("push7_push_pt_".$post_type, null) === "false");
+    $setting = get_option("push7_push_pt_".$post_type, null);
+    // TODO: 何故かsettings.phpでcheckboxを外して保存した場合, 'false'ではなく空文字が設定されることがあるため以下のような検証を行っている
+    return $setting === 'false' || $setting === '';
   }
 
   public function check_ignored_category($post_id){
     $categories = get_the_category($post->ID);
     foreach ($categories as $category) {
-      if(get_option("push7_push_ctg_".$category->slug, null) === "false"){
-        return false;
-      }
+      if (get_option('push7_push_ctg_'.$category->slug, null) === 'false') return true;
     }
-    return true;
+    return false;
   }
 
   /**

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -60,16 +60,17 @@ class Push7_Post {
   public function push($post, $is_rp=false) {
     if (isset($_REQUEST['push7_not_notify'])) return;
 
+    $post_id = $this->get_post_id($post);
+
     if ($is_rp) {
-      $rp_id = $this->get_rpid_from_post_data($this->get_post_id($post));
+      $rp_id = $this->get_rpid_from_post_data($post_id);
       if ($rp_id) return;
     }
 
     $post_type = get_post_type($post_id);
-    $post_id = $this->get_post_id($post);
 
     if ($this->check_ignored_posttype($post_id)) return;
-    // 通常投稿の場合のみカテゴリチェックを行う
+    // 通常投稿の場合のみカテゴリが存在するので、チェックを行う
     if ($post_type === 'post' && $this->check_ignored_category($post_id)) return;
 
     $blogname = get_option(get_option('push7_blog_title', '') === '' ? 'blogname' : 'push7_blog_title');

--- a/classes/push7.php
+++ b/classes/push7.php
@@ -2,7 +2,7 @@
 
 class Push7 {
   const API_URL = 'https://api.push7.jp/api/v1/';
-  const VERSION = '3.0.4';
+  const VERSION = '3.0.5';
 
   public function __construct() {
     new Push7_Admin_Menu();

--- a/push7.php
+++ b/push7.php
@@ -4,7 +4,7 @@
 Plugin Name: Push7
 Plugin URI: https://push7.jp/
 Description: Push7 plugin for WordPress
-Version: 3.0.4
+Version: 3.0.5
 Author: GNEX Ltd.
 Author URI: https://globalnet-ex.com
 License:GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gnexltd
 Tags: Chrome, Chrome Notifications, Android, Safari, push, push notifications, web push notifications, web push, plugin, admin, posts, page, links, widget, ajax, social, wordpress, dashboard, news, notifications, services, desktop notifications, mobile notifications, apple, google, Firefox, new post, osx, mac, Chrome OS
 Requires at least: 4.0
 Tested up to: 4.4.1
-Stable tag: 3.0.4
+Stable tag: 3.0.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,9 @@ Push7 is now available for Chrome(Android and desktop).
 1. Open the settings menu, input your APPNO and APIKEY.
 
 == Changelog ==
+= 3.0.5 =
+* 投稿カテゴリの設定が適用されない問題を修正
+
 = 3.0.4 =
 * 予約投稿が配信されない問題を解消
 

--- a/setting.php
+++ b/setting.php
@@ -110,7 +110,7 @@ function show_advances_info() {
 
 
     <?php
-      if(count(Push7::post_types()) >= 2){
+      if (count(Push7::post_types()) >= 2) {
     ?>
         <h2 class="title">投稿タイプ毎のプッシュ通知設定</h2>
         <table class="form-table">
@@ -120,12 +120,11 @@ function show_advances_info() {
               <td>
               <?php
                 foreach (Push7::post_types() as $post_type) {
-                  if($post_type == "post") continue;
                   $name = "push7_push_pt_".$post_type;
               ?>
                   <label for="<?= $name; ?>">
                     <input type="checkbox" name="<?= $name;?>" value="true" <?php checked("true", get_option($name)) ?>>
-                    <?= $post_type == 'post' ? 'post(通常の投稿)' : $post_type; ?>
+                    <?= $post_type === 'post' ? 'post(通常の投稿)' : $post_type; ?>
                   </label>
                   <br>
               <?php


### PR DESCRIPTION
## WHAT 
- same as title
- 多少のリファクタリングを行った(記法の統一)

## バグ内容と修正箇所
カスタム投稿タイプではカテゴリが存在しないため、通常投稿のみカテゴリはチェックすれば良い。
また、設定でチェックボックスを外して保存した場合、`'false'`が保存される場合と、`''`が保存される場合が混在しているため、両方のパターンに対応するようにした。(今回のバグの直接の原因はここ)
