### PR TITLE
通知を送信しないカスタム投稿タイプの値を `'false'` から空文字に変更

### DIFF
--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -169,9 +169,8 @@ class Push7_Post {
 
   public function check_ignored_posttype($post_id){
     $post_type = get_post_type($post_id);
-    $setting = get_option("push7_push_pt_".$post_type, null);
-    // TODO: 何故かsettings.phpでcheckboxを外して保存した場合, 'false'ではなく空文字が設定されることがあるため以下のような検証を行っている
-    return $setting === 'false' || $setting === '';
+    $setting = get_option("push7_push_pt_".$post_type, '');
+    return $setting === '';
   }
 
   public function check_ignored_category($post_id){

--- a/classes/push7-post.php
+++ b/classes/push7-post.php
@@ -91,7 +91,8 @@ class Push7_Post {
       'body' => $post->post_title,
       'icon' => $icon_url,
       'url' => get_permalink($post),
-      'apikey' => $apikey
+      'apikey' => $apikey,
+      'transmission_time' => date("Y-m-d H:i")
     );
 
     // push7の予約投稿は分粒度での配信しかできないため、1分追加しないと記事公開前にpushが配送される可能性が高い.

--- a/classes/push7.php
+++ b/classes/push7.php
@@ -96,26 +96,38 @@ class Push7 {
      *  - ''(空文字): 通知を送信しない場合（チェックボックスにチェックが入っていない）
      *  - 'false': 過去に空文字と同じ意味合いで使われていた値
      */
-    foreach (Push7::post_types() as $post_type) {
-      $opt = "push7_push_pt_".$post_type;
-      register_setting('push7-settings-group', $opt);
+    if(count(Push7::post_types()) >= 2) {
+      // カスタム投稿タイプの設定が表示されている場合
+      foreach (Push7::post_types() as $post_type) {
+        $opt = "push7_push_pt_".$post_type;
+        register_setting('push7-settings-group', $opt);
 
-      // 記事のデフォルトは 'true', それ以外の投稿タイプのデフォルトは空文字(通知を送信しない)
-      $default_value = $post_type === 'post' ? 'true' : '';
-      $opt_value = get_option($opt);
+        // 記事のデフォルトは 'true', それ以外の投稿タイプのデフォルトは空文字(通知を送信しない)
+        $default_value = $post_type === 'post' ? 'true' : '';
+        $opt_value = get_option($opt, $default_value);
 
-      // true もしくは ''(空文字) が想定される値
-      if($opt_value === 'true' || $opt_value === '') continue;
+        // true もしくは ''(空文字) が想定される値
+        if($opt_value === 'true' || $opt_value === '') continue;
 
-      /* 後方互換性の維持コード */
-      if($opt_value === 'false') {
-        // 過去に空文字ではなく false が設定されていたことがあるので, 空文字に置き換える
-        update_option($opt, '');
-        continue;
+        /* 後方互換性の維持コード */
+        if($opt_value === 'false') {
+          // 過去に空文字ではなく false が設定されていたことがあるので, 空文字に置き換える
+          update_option($opt, '');
+          continue;
+        }
+
+        // その他の予期しない値が入っている, もしくは値が設定されていない場合, デフォルト値を設定する
+        update_option($opt, $default_value);
       }
-
-      // その他の予期しない値が入っている, もしくは値が設定されていない場合, デフォルト値を設定する
-      update_option($opt, $default_value);
+    } else {
+      // カスタム投稿タイプ設定が表示されていない場合 -> postはPush通知を送信する
+      $opt = 'push7_push_pt_post';
+      $default_value = 'true';
+      $opt_value = get_option($opt);
+      if($opt_value !== $default_value) {
+        // optionに既にデフォルト値が入っていない場合, 自動的にデフォルト値を書き込む
+        update_option($opt, $default_value);
+      }
     }
   }
 

--- a/classes/push7.php
+++ b/classes/push7.php
@@ -88,11 +88,34 @@ class Push7 {
       if (get_option($opt, null) === '') update_option($opt, 'false');
     }
 
+    /**
+     * カスタム投稿タイプごとの送信設定
+     * Key: push7_push_pt_$post_type
+     * Value:
+     *  - 'true': 通知を送信する場合
+     *  - ''(空文字): 通知を送信しない場合（チェックボックスにチェックが入っていない）
+     *  - 'false': 過去に空文字と同じ意味合いで使われていた値
+     */
     foreach (Push7::post_types() as $post_type) {
       $opt = "push7_push_pt_".$post_type;
       register_setting('push7-settings-group', $opt);
-      if (!is_null(get_option($opt, null))) continue;
-      update_option($opt, ($post_type === 'post') ? 'true' : 'false');
+
+      // 記事のデフォルトは 'true', それ以外の投稿タイプのデフォルトは空文字(通知を送信しない)
+      $default_value = $post_type === 'post' ? 'true' : '';
+      $opt_value = get_option($opt);
+
+      // true もしくは ''(空文字) が想定される値
+      if($opt_value === 'true' || $opt_value === '') continue;
+
+      /* 後方互換性の維持コード */
+      if($opt_value === 'false') {
+        // 過去に空文字ではなく false が設定されていたことがあるので, 空文字に置き換える
+        update_option($opt, '');
+        continue;
+      }
+
+      // その他の予期しない値が入っている, もしくは値が設定されていない場合, デフォルト値を設定する
+      update_option($opt, $default_value);
     }
   }
 

--- a/setting.php
+++ b/setting.php
@@ -23,7 +23,7 @@ function show_advances_info() {
           </th>
           <td>
             <?php
-              if (get_option('blog_title')) {
+              if (get_option('push7_blog_title')) {
             ?>
                 <input type="text" id="push7_blog_title" class="regular-text" name="push7_blog_title" value="<?= esc_attr( get_option( 'push7_blog_title' ) ); ?>">
             <?php


### PR DESCRIPTION
## カスタム投稿タイプが存在しない場合のハンドリング

設定画面から通知を送信するカスタム投稿タイプを設定する際, 以下のコードが使われている。

https://github.com/gnexltd/push7-wp-plugin/blob/f15c311d33ad49153b6ac34d90e4098ae4a2fe27/setting.php#L112-L139

このコードでは、ユーザーが独自にカスタム投稿タイプを作っていない場合、input要素が生成されない。しかし、 `push7-settings-group` が `settings_fields` として指定されているため、WordPress側でNULLとして扱われ、MySQLに挿入される段階で空文字になる。

https://github.com/gnexltd/push7-wp-plugin/blob/f15c311d33ad49153b6ac34d90e4098ae4a2fe27/classes/push7-post.php#L170-L175

その後、ここで空文字が拾われ、当該の投稿タイプについて通知が送信されなくなってしまう。一般的に使われるデフォルトのPostに関してこれが発生してしまっている。

そこで、optionとして扱う値を

- チェックボックスが外れている場合: 空文字
- チェックボックスが入っている場合: 'true'

とし、これまで使われていた `false` に関しては空文字に更新するようにした。

カスタム投稿タイプが追加されていない場合には、投稿タイプPostの値を問答無用で `true` とすることとした。これによって、意図通りpostでは通知がデフォルトで送信される。

## すべての通知への `transmission_time` の設定

予約投稿ではない即時に公開される通知に関しても、 `transmission_time` を設定することでサーバー側で非同期的に処理し、購読者が多いアプリケーションでもタイムアウトしないようにした。

## オプションキーの修正

`blog_title` と `push7_blog_title` とキー名に揺れがあったので修正した。
